### PR TITLE
Support generating JDK 8 Javadoc using JDK 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -538,6 +538,13 @@
                             </goals>
                         </execution>
                     </executions>
+                    <configuration>
+                        <!-- All relevant doclint checks are performed during
+                        the compilation phase; no need to recheck during
+                        Javadoc generation. -->
+                        <doclint>none</doclint>
+                        <source>${version.jdk}</source>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
While there: avoid uninteresting warnings while generating Javadoc.