### PR TITLE
Link to HTTPS version of `picnic.tech`

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ conventions and style in order to keep the configuration as readable as
 possible.
 
 [maven-central-badge]: https://img.shields.io/maven-central/v/tech.picnic/oss-parent.svg
-[maven-central-browse]: https://repo1.maven.org/maven2/tech/picnic/oss-parent
+[maven-central-browse]: https://repo1.maven.org/maven2/tech/picnic/oss-parent/
 [maven-central-search]: https://search.maven.org
 [new-issue]: https://github.com/PicnicSupermarket/oss-parent/issues/new
 [new-pr]: https://github.com/PicnicSupermarket/oss-parent/compare

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <inceptionYear>2019</inceptionYear>
     <organization>
         <name>Picnic Technologies BV</name>
-        <url>http://picnic.tech</url>
+        <url>https://picnic.tech</url>
     </organization>
     <licenses>
         <license>


### PR DESCRIPTION
While there: sync `maven-central-browse` link format with other repositories (see PicnicSupermarket/jolo#1).