### PR TITLE
Fix PIT JUnit 5 compatibility support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -730,7 +730,7 @@
                         <dependency>
                             <groupId>org.pitest</groupId>
                             <artifactId>pitest-junit5-plugin</artifactId>
-                            <version>0.10</version>
+                            <version>0.11</version>
                         </dependency>
                     </dependencies>
                 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -726,6 +726,13 @@
                         <timeoutFactor>4</timeoutFactor>
                         <timestampedReports>false</timestampedReports>
                     </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.pitest</groupId>
+                            <artifactId>pitest-junit5-plugin</artifactId>
+                            <version>0.10</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.sonarsource.scanner.maven</groupId>


### PR DESCRIPTION
The migration from TestNG to JUnit 5 broke support for mutation coverage
calculation. This change restores support.

See also hcoles/pitest#284.

Confirmed working with `reactive-support`. https://github.com/PicnicSupermarket/reactive-support/pull/46 can thus be closed in favor of this. Also bumped the version from `0.8` to `0.10`.