### PR TITLE
Fix invalid schedule in Renovate config

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -5,7 +5,7 @@
       "packageNames": [
         "version.mockito"
       ],
-      "schedule": "every Monday"
+      "schedule": "on Monday"
     }
   ]
 }


### PR DESCRIPTION
Renovate runs failed because of invalid settings.

> Invalid schedule: Failed to parse \"every Monday\"

Apparently, it should be `on Monday`. See https://breejs.github.io/later/parsers.html#text.