### PR TITLE
Run Sonar analysis for JDK11 instead

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,11 @@ language: java
 matrix:
   include:
     - jdk: openjdk8
+      script: ./mvnw install
+    - jdk: openjdk11
       # This is the primary target platform. In this build perform a SonarQube
       # analysis.
       script: ./mvnw install sonar:sonar
-    - jdk: openjdk11
-      script: ./mvnw install
 addons:
   sonarcloud:
     organization: picnic-technologies


### PR DESCRIPTION
JDK8 is no longer supported by Sonar as of February 1st 2021.