### PR TITLE
Update TravisCI `ciManagement` reference

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     </issueManagement>
     <ciManagement>
         <system>Travis CI</system>
-        <url>https://travis-ci.org/PicnicSupermarket/oss-parent</url>
+        <url>https://travis-ci.com/PicnicSupermarket/oss-parent</url>
     </ciManagement>
     <distributionManagement>
         <repository>


### PR DESCRIPTION
https://travis-ci.org is being phased out in favor of https://travis-ci.com.

See:
- https://docs.travis-ci.com/user/migrate/open-source-repository-migration