### PR TITLE
Override Renovate `commitMessagePrefix` option

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,5 +1,6 @@
 {
-  "$schema": "https://json.schemastore.org/renovate",
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "commitMessagePrefix": "",
   "packageRules": [
     {
       "packagePatterns": [


### PR DESCRIPTION
I want to push this configuration to repositories.